### PR TITLE
Changes to template save implementation

### DIFF
--- a/app/edit.js
+++ b/app/edit.js
@@ -15,6 +15,15 @@ $(function() {
 });
 
 
+function add_frames_between(start, end, delta) {
+	$('#sortable .action .frame_input').each(function() {
+		var value = +this.value
+		if (value > start && value < end) {
+			this.value = value+delta
+		}
+	})
+}
+
 function createActionRow(frameNumber) {
 	var row = $("<tr class='entry action'><td class='drag_handle' style='vertical-align:middle;'>☰</td></tr>")
 	row.append("<td><input class='frame_input' value='" + frameNumber + "''></td>")

--- a/app/index.html
+++ b/app/index.html
@@ -83,7 +83,7 @@
 						<button type="button" class="btn btn-default col-sm-2 col-sm-offset-1" onclick="set_savefile_path()">Set savefile path</button>
 					</div>
 					<div class="row">
-						<div class=col-sm-9>
+						<div class="col-sm-9">
 							<label class="h4">Clear all saves <input id="cb_clear_saves" type="checkbox"></label>
 							<span style="margin:20px;"></span>
 							<label class="h4">Insert template save <input id="cb_template_saves" type="checkbox"></label>
@@ -99,6 +99,32 @@
 		</div>
 	</div>
 
+	<!-- TEMPLATE SAVES MODAL -->
+	<div class="modal fade" id="template_save_modal" tabindex="-1">
+		<div class="modal-dialog modal-lg">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+					<h1 class="modal-title">Template saveslots</h1>
+				</div>
+				<div class="modal-body settings_container">
+					<table class="table" id="template_savefiles_table">
+						<tr>
+							<th>Name</th>
+							<th width="100px">File</th>
+							<th>Delete</th>
+						</tr>
+					</table>
+					<button type="button" class="btn btn-success col-sm-offset-9" id="template_save_add" onclick="add_template_save()">Add new templatesave</button>
+					<br><br>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+					<button type="button" class="btn btn-primary" onclick="template_saves_save_changes()">Save changes</button>
+				</div>
+			</div>
+		</div>
+	</div>
 
 	<main>
 
@@ -122,7 +148,16 @@
 					 </span>
 					<input class="form-control" id="skip_frame" value="1">
     		</div>
-				<div class="col-sm-3"></div>
+				<div class="input-group col-sm-4">
+				<span class="input-group-addon"><label style="margin:0">Template save:</label></span>
+				<select id="ddl_template_save" class="form-control">
+					<option value="none">None</option>
+					<option value="clear">Clear</option>
+				</select>
+				<div class="input-group-addon">
+				<button type="button" class="btn btn-primary" aria-label="Help" onclick="template_saves_edit_click()">Edit</button>
+			</div>
+				</div>
 			</div>
 
 			<br>
@@ -158,5 +193,6 @@
 <script src="save_load.js"></script>
 <script src="run_compile.js"></script>
 <script src="edit.js"></script>
+<script src="template_saves.js"></script>
 </body>
 </html>

--- a/app/run_compile.js
+++ b/app/run_compile.js
@@ -79,19 +79,19 @@ function runTAS(should_compile) {
 		}
 	}
 
-	if (settings['clear-saves']) {
-		for (var i = 0;i<3;i++) {
-			var slot_path = path.join(settings['savefiles-path'], 'save'+i+'.dat');
-			if (fs.existsSync(slot_path)) {
-				fs.removeSync(slot_path);
+	if (ddl_template_save.selectedIndex != 0) {
+			for (var i = 0;i<3;i++) {
+				var slot_path = path.join(settings['savefiles-path'], 'save'+i+'.dat');
+				if (fs.existsSync(slot_path)) {
+					fs.removeSync(slot_path);
+				}
 			}
-		}
-	}
 
-	if (settings['insert-template']) {
-		if (fs.existsSync(path.join(settings['savefiles-path'], 'save3.dat'))) {
-			fs.copySync(path.join(settings['savefiles-path'], 'save3.dat'), path.join(settings['savefiles-path'], 'save0.dat'))
-		}
+			let savefile = $(ddl_template_save.selectedOptions[0]).data('savefile');
+
+			if (settings['insert-template'] && savefile) {
+				write_to_file(path.join(settings['savefiles-path'], 'save0.dat'), iconv.decode(savefile,'win1252'))
+			}
 	}
 
 	try {

--- a/app/save_load.js
+++ b/app/save_load.js
@@ -3,7 +3,8 @@ function tasToJSON() {
 		'entries': [],
 		'boss_frame': $('#boss_frame').val(),
 		'should_skip_dialogue': $('#cb_dialogue_skipping')[0].checked,
-		'dialogue_skip_frame': $('#skip_frame').val()
+		'dialogue_skip_frame': $('#skip_frame').val(),
+		'template-saves' : template_saves_to_list()
 	};
 	$(".entry").each(function() {
 		var entry = {};
@@ -73,6 +74,7 @@ function jsonToTAS(data) {
 	$('#skip_frame').val(js_object['dialogue_skip_frame'])
 	$('#cb_dialogue_skipping').prop('checked',js_object['should_skip_dialogue'])
 	toggle_dialogue_skipping()
+	load_template_saves(js_object['template-saves'])
 }
 
 function loadFromFile() {

--- a/app/style.css
+++ b/app/style.css
@@ -122,6 +122,10 @@ td .ui-spinner-input {
   margin-left: 5px;
 }
 
+#ddl_template_save {
+  height: 50px;
+}
+
 span.skipping + span.ui-spinner {
   border-radius: 0 4px 4px 0;
   width: 0px;
@@ -133,6 +137,8 @@ span.skipping + span.ui-spinner {
 }
 
 .button:hover {
+  cursor: pointer;
+  text-decoration: none;
   opacity: 0.5;
 }
 

--- a/app/template_saves.js
+++ b/app/template_saves.js
@@ -1,0 +1,74 @@
+function template_saves_edit_click() {
+  var table = document.getElementById("template_savefiles_table");
+  table.getElementsByTagName("tbody")[0].innerHTML = table.rows[0].innerHTML;
+
+  var template_saves = template_saves_to_list()
+  for (var i in template_saves) {
+    let name = template_saves[i]['name']
+    let data = template_saves[i]['savefile']
+    create_template_save_table_row(table, name, data)
+  }
+  $('#template_save_modal').modal('show');
+}
+
+function template_saves_save_changes() {
+  var savelist = [];
+  $('#template_savefiles_table').find('input').each(function(i) {
+    savelist.push({'name':this.value, 'savefile':$(this).data('savefile')})
+  })
+  load_template_saves(savelist);
+  $('#template_save_modal').modal('hide');
+  return;
+}
+
+function create_template_save_table_row(table, name, data) {
+  var row = table.insertRow();
+  $(row.insertCell()).append($('<input class="form-control" value="' + name + '">').data('savefile', data));
+  row.insertCell().innerHTML = '<a class="button" onclick="set_or_change_templatesave(this)">Set/Change</a>';
+  row.insertCell().innerHTML = '<i style="color:darkred;" onclick="remove_template_save(this)" class="glyphicon glyphicon-remove button"></i>'
+}
+
+function set_or_change_templatesave(button) {
+  var path = get_path_from_dialog({defaultpath:'save0.dat',title:'Select savefile to add',filters: [{ name: 'OTS savefile', extensions: ['dat'] },{ name: 'All files', extensions: ['*'] }]})
+  if (path) {
+    console.log(path)
+    let input = $(button).closest('tr').find('input')
+    let savefile = [...read_from_file(path)]
+    input.data('savefile', savefile)
+  }
+}
+
+function add_template_save() {
+  create_template_save_table_row(template_savefiles_table, '', [])
+}
+
+function remove_template_save(button) {
+  template_savefiles_table.deleteRow($(button).closest('tr')[0].rowIndex)
+}
+
+function load_template_saves(save_list) {
+	var ddl = document.getElementById('ddl_template_save')
+	ddl.innerHTML = ""
+	ddl.add(new Option('None', 'none'))
+	ddl.add(new Option('Clear', 'clear'))
+	if (save_list) {
+		for (let template_save of save_list) {
+			var opt = new Option(template_save['name'], template_save['name'])
+			$(opt).data('savefile',template_save['savefile'])
+			ddl.add(opt)
+		}
+	}
+	return;
+}
+
+function template_saves_to_list() {
+	var save_list = []
+  var options = document.getElementById('ddl_template_save').options
+	for (let opt of options) {
+		if (opt.index < 2) {
+			continue;
+		}
+		save_list.push({'name':opt.value, 'savefile': $(opt).data('savefile')})
+	}
+	return save_list
+}

--- a/app/utils.js
+++ b/app/utils.js
@@ -6,6 +6,7 @@ const remote = require('electron').remote;
 const dialog = remote.dialog;
 const fs = require('fs-extra');
 const shell = require('child_process');
+const iconv = require('iconv-lite');
 
 
 // GLOBAL VARS
@@ -80,7 +81,7 @@ function read_from_file(path) {
 
 function write_to_file(path, data) {
   try {
-    fs.writeFileSync(path, data)
+    fs.writeFileSync(path, iconv.encode(data,'win1252'))
     return true;
   } catch (e) {
     // HANDLE ERROR!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,45 +1,19 @@
 {
 	"name": "OtsTasTool",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"7zip-bin": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.4.1.tgz",
-			"integrity": "sha512-QU3oR1dLLVrYGRkb7LU17jMCpIkWtXXW7q71ECXWXkR9vOv37VjykqpvFgs29HgSCNLZHnNKJzdG6RwAW0LwIA==",
-			"dev": true,
-			"requires": {
-				"7zip-bin-linux": "1.3.1",
-				"7zip-bin-mac": "1.0.1",
-				"7zip-bin-win": "2.1.1"
-			}
-		},
-		"7zip-bin-linux": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-			"integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-			"dev": true,
-			"optional": true
-		},
-		"7zip-bin-mac": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
-			"integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
-			"dev": true,
-			"optional": true
-		},
-		"7zip-bin-win": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
-			"integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ==",
-			"dev": true,
-			"optional": true
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-3.0.0.tgz",
+			"integrity": "sha512-CYsciSeLZvl+hlJiDBBEh987fyqvFFFJG3nZi8QbNYgmgxNOzf+kyYuAYIR48CTc/X6SX5d5KtTgvkUlj9jLQA==",
+			"dev": true
 		},
 		"@types/node": {
-			"version": "7.0.52",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
-			"integrity": "sha512-jjpyQsKGsOF/wUElNjfPULk+d8PKvJOIXk3IUeBYYmNCy5dMWfrI+JiixYNw8ppKOlcRwWTXFl0B+i5oGrf95Q==",
+			"version": "8.10.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.16.tgz",
+			"integrity": "sha512-KlK7YiZXSY8E6v8E4+cCor9IT071bfZrfYqKf0SEj8SJ0Qk4DEz1sgL02Wt6mebNNM9d7870PEoJRHAsUcJPrw==",
 			"dev": true
 		},
 		"abbrev": {
@@ -52,10 +26,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -70,7 +44,7 @@
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -91,8 +65,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -101,7 +75,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -113,21 +87,21 @@
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-find-index": {
@@ -137,17 +111,17 @@
 			"dev": true
 		},
 		"asar": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/asar/-/asar-0.14.0.tgz",
-			"integrity": "sha512-l21mf5pG65qbtD5WhymthfbE7ash0goQ+5ayo3lIncxtFNYH1PVArqsGXoAUXOd877mJplWSD9nGumByzQqVSA==",
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/asar/-/asar-0.14.3.tgz",
+			"integrity": "sha512-+hNnVVDmYbv05We/a9knj/98w171+A94A9DNHj+3kXUr3ENTQoSEcfbJRvBBRHyOh4vukBYWujmHvvaMmQoQbg==",
 			"requires": {
-				"chromium-pickle-js": "0.2.0",
-				"commander": "2.13.0",
-				"cuint": "0.2.2",
-				"glob": "6.0.4",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"mksnapshot": "0.3.1",
+				"chromium-pickle-js": "^0.2.0",
+				"commander": "^2.9.0",
+				"cuint": "^0.2.1",
+				"glob": "^6.0.4",
+				"minimatch": "^3.0.3",
+				"mkdirp": "^0.5.0",
+				"mksnapshot": "^0.3.0",
 				"tmp": "0.0.28"
 			},
 			"dependencies": {
@@ -156,11 +130,11 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
 					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -171,8 +145,8 @@
 			"integrity": "sha512-6UDOmyl4RUo8i/0Sem/UKFJ70XZrXLCDQcILTbjTjAKZrSA3JbXVnWRFi2ZFEbeZxQ2LVCc3CWHnDlqj2AyVXg==",
 			"dev": true,
 			"requires": {
-				"bluebird-lst": "1.0.5",
-				"fs-extra-p": "4.5.0"
+				"bluebird-lst": "^1.0.5",
+				"fs-extra-p": "^4.5.0"
 			}
 		},
 		"asn1": {
@@ -202,9 +176,9 @@
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -223,7 +197,7 @@
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"binary": {
@@ -231,8 +205,8 @@
 			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
 			"requires": {
-				"buffers": "0.1.1",
-				"chainsaw": "0.1.0"
+				"buffers": "~0.1.1",
+				"chainsaw": "~0.1.0"
 			}
 		},
 		"bluebird": {
@@ -247,7 +221,7 @@
 			"integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "3.5.1"
+				"bluebird": "^3.5.1"
 			}
 		},
 		"boom": {
@@ -255,7 +229,7 @@
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"bootstrap": {
@@ -269,13 +243,13 @@
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 			"dev": true,
 			"requires": {
-				"ansi-align": "2.0.0",
-				"camelcase": "4.1.0",
-				"chalk": "2.3.0",
-				"cli-boxes": "1.0.0",
-				"string-width": "2.1.1",
-				"term-size": "1.2.0",
-				"widest-line": "2.0.0"
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -302,8 +276,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -312,7 +286,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -322,9 +296,15 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
+		},
+		"buffer-from": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+			"dev": true
 		},
 		"buffers": {
 			"version": "0.1.1",
@@ -332,26 +312,26 @@
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
 		},
 		"builder-util": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-4.2.1.tgz",
-			"integrity": "sha512-yebI1DSH5YMGNtwGyrJclhun4HdKvYbDa/iYiZgTb8XwMp7Qx/i1j+JEEBFWTwG+wWOkNnP2EnVQfGPqtVMYSA==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-4.2.4.tgz",
+			"integrity": "sha512-4MOB8Lfox9Exxmz0DDClTWRrtxYUy8/U6JbyAph1Y4Ha8DUQKKPYqEeobNEz0ZiwbNBli08HtyjjhN+RI/JF1w==",
 			"dev": true,
 			"requires": {
-				"7zip-bin": "2.4.1",
-				"bluebird-lst": "1.0.5",
-				"builder-util-runtime": "4.0.3",
-				"chalk": "2.3.0",
-				"debug": "3.1.0",
-				"fs-extra-p": "4.5.0",
-				"ini": "1.3.5",
-				"is-ci": "1.1.0",
-				"js-yaml": "3.10.0",
-				"lazy-val": "1.0.3",
-				"semver": "5.5.0",
-				"source-map-support": "0.5.2",
-				"stat-mode": "0.2.2",
-				"temp-file": "3.1.1",
-				"tunnel-agent": "0.6.0"
+				"7zip-bin": "~3.0.0",
+				"bluebird-lst": "^1.0.5",
+				"builder-util-runtime": "^4.0.4",
+				"chalk": "^2.3.0",
+				"debug": "^3.1.0",
+				"fs-extra-p": "^4.5.0",
+				"ini": "^1.3.5",
+				"is-ci": "^1.1.0",
+				"js-yaml": "^3.10.0",
+				"lazy-val": "^1.0.3",
+				"semver": "^5.5.0",
+				"source-map-support": "^0.5.3",
+				"stat-mode": "^0.2.2",
+				"temp-file": "^3.1.1",
+				"tunnel-agent": "^0.6.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -366,15 +346,15 @@
 			}
 		},
 		"builder-util-runtime": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-4.0.3.tgz",
-			"integrity": "sha512-OgrYhUr/neAXSAIR4zw9icC8dbqs8lT23L3KpXX+htl6y3rPLVt3U2Y2b+8zURx6qgG19454V3Kr++XQKB5DMQ==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-4.0.4.tgz",
+			"integrity": "sha512-WyTMyWXX7zahY0MyR8Fh8SRxH//ugUaBgsgrCT/orwTv5ud4s0htLlucNiQdDTiWdHyQFqAigTfqILED4bAXUA==",
 			"dev": true,
 			"requires": {
-				"bluebird-lst": "1.0.5",
-				"debug": "3.1.0",
-				"fs-extra-p": "4.5.0",
-				"sax": "1.2.4"
+				"bluebird-lst": "^1.0.5",
+				"debug": "^3.1.0",
+				"fs-extra-p": "^4.5.0",
+				"sax": "^1.2.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -405,8 +385,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
 			}
 		},
 		"capture-stack-trace": {
@@ -425,18 +405,18 @@
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
 			"requires": {
-				"traverse": "0.3.9"
+				"traverse": ">=0.3.0 <0.4"
 			}
 		},
 		"chalk": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-			"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "4.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chromium-pickle-js": {
@@ -445,9 +425,9 @@
 			"integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU="
 		},
 		"ci-info": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
 			"dev": true
 		},
 		"cli-boxes": {
@@ -457,14 +437,14 @@
 			"dev": true
 		},
 		"cliui": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-			"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"wrap-ansi": "2.1.0"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -485,8 +465,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -495,7 +475,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -517,7 +497,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -527,17 +507,17 @@
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"compare-version": {
 			"version": "0.1.2",
@@ -556,9 +536,9 @@
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			},
 			"dependencies": {
 				"isarray": {
@@ -568,43 +548,43 @@
 					"dev": true
 				},
 				"readable-stream": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"string_decoder": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
 		},
 		"configstore": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "4.2.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.1.0",
-				"unique-string": "1.0.0",
-				"write-file-atomic": "2.3.0",
-				"xdg-basedir": "3.0.0"
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			}
 		},
 		"core-util-is": {
@@ -618,7 +598,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "1.0.0"
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -627,9 +607,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cryptiles": {
@@ -637,7 +617,7 @@
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -645,7 +625,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -667,7 +647,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"dashdash": {
@@ -675,7 +655,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -698,19 +678,19 @@
 			"resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
 			"integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
 			"requires": {
-				"binary": "0.3.0",
-				"graceful-fs": "4.1.11",
-				"mkpath": "0.1.0",
-				"nopt": "3.0.6",
-				"q": "1.5.1",
-				"readable-stream": "1.1.14",
+				"binary": "^0.3.0",
+				"graceful-fs": "^4.1.3",
+				"mkpath": "^0.1.0",
+				"nopt": "^3.0.1",
+				"q": "^1.1.2",
+				"readable-stream": "^1.1.8",
 				"touch": "0.0.3"
 			}
 		},
 		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
 			"dev": true
 		},
 		"delayed-stream": {
@@ -719,17 +699,17 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"dmg-builder": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-3.1.3.tgz",
-			"integrity": "sha512-gysVZIdmAdfB3FFa7UBERESNobQVE+Z40up1LlRBHtVyCXPUc/1XOLU2wsC0ySvL76OZA6vxeqFJrnCjp6l37A==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-3.1.4.tgz",
+			"integrity": "sha512-nobhBdmpA8XmJM13rjvhLQOMUUM9HNyZjXmvFWCZPK8A8sP2rJciQDOzvJoc2ioFehR7vfLbWHNpKgYQrSPIPw==",
 			"dev": true,
 			"requires": {
-				"bluebird-lst": "1.0.5",
-				"builder-util": "4.2.1",
-				"fs-extra-p": "4.5.0",
-				"iconv-lite": "0.4.19",
-				"js-yaml": "3.10.0",
-				"parse-color": "1.0.0"
+				"bluebird-lst": "^1.0.5",
+				"builder-util": "^4.2.2",
+				"fs-extra-p": "^4.5.0",
+				"iconv-lite": "^0.4.19",
+				"js-yaml": "^3.10.0",
+				"parse-color": "^1.0.0"
 			}
 		},
 		"dot-prop": {
@@ -738,7 +718,7 @@
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"dotenv": {
@@ -748,9 +728,9 @@
 			"dev": true
 		},
 		"dotenv-expand": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.0.1.tgz",
-			"integrity": "sha1-aP3cFWGBTgoQlkERBX/xOM7X16g=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
+			"integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
 			"dev": true
 		},
 		"duplexer3": {
@@ -765,45 +745,45 @@
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"ejs": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-			"integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
 			"dev": true
 		},
 		"electron": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-1.6.16.tgz",
-			"integrity": "sha1-83qPScwmJQWcmesmbe5N/+CRe2M=",
+			"version": "1.8.7",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-1.8.7.tgz",
+			"integrity": "sha512-q6dn8bspX8u8z6tNU4bEas6ZrdNavnrjJ6d/oz49Nb4zFIPrdh8p29AFjFlSAavypGwAVR/PhYOAGwzZSQSSVQ==",
 			"dev": true,
 			"requires": {
-				"@types/node": "7.0.52",
-				"electron-download": "3.3.0",
-				"extract-zip": "1.6.6"
+				"@types/node": "^8.0.24",
+				"electron-download": "^3.0.1",
+				"extract-zip": "^1.0.3"
 			}
 		},
 		"electron-builder": {
-			"version": "19.55.2",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.55.2.tgz",
-			"integrity": "sha512-6tUXErylz3egsZzg1DO81lRnAZDHPbIiR5I6pw+MkzcYKZbJ0VZaLWqM3EehGEFSyeT59Ih3z4v5smlw5Q+PSg==",
+			"version": "19.56.2",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.56.2.tgz",
+			"integrity": "sha512-3t6FY4Q/TPwkuL5XKSssBD0GKudWjYfMJcDIVWOE2okBfMB3LYkRj2FWG4ZxJ1FcybXLFSswQQZVbwiYpLIYxA==",
 			"dev": true,
 			"requires": {
-				"bluebird-lst": "1.0.5",
-				"builder-util": "4.2.1",
-				"builder-util-runtime": "4.0.3",
-				"chalk": "2.3.0",
-				"electron-builder-lib": "19.55.2",
+				"bluebird-lst": "^1.0.5",
+				"builder-util": "4.2.4",
+				"builder-util-runtime": "4.0.4",
+				"chalk": "^2.3.0",
+				"electron-builder-lib": "19.56.2",
 				"electron-download-tf": "4.3.4",
-				"fs-extra-p": "4.5.0",
-				"is-ci": "1.1.0",
-				"lazy-val": "1.0.3",
+				"fs-extra-p": "^4.5.0",
+				"is-ci": "^1.1.0",
+				"lazy-val": "^1.0.3",
 				"read-config-file": "2.1.1",
-				"sanitize-filename": "1.6.1",
-				"update-notifier": "2.3.0",
-				"yargs": "10.1.1"
+				"sanitize-filename": "^1.6.1",
+				"update-notifier": "^2.3.0",
+				"yargs": "^11.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -821,15 +801,15 @@
 					"integrity": "sha512-SQYDGMLpTgty1bx3NycuDb7dNPzktVSdK2sqPZjyRocauq/uN/V4S2lcpFVLupaHhKlD8zozm9fTpm5UdohvTg==",
 					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"env-paths": "1.0.0",
-						"fs-extra": "4.0.3",
-						"minimist": "1.2.0",
-						"nugget": "2.0.1",
-						"path-exists": "3.0.0",
-						"rc": "1.2.4",
-						"semver": "5.5.0",
-						"sumchecker": "2.0.2"
+						"debug": "^3.0.0",
+						"env-paths": "^1.0.0",
+						"fs-extra": "^4.0.1",
+						"minimist": "^1.2.0",
+						"nugget": "^2.0.1",
+						"path-exists": "^3.0.0",
+						"rc": "^1.2.1",
+						"semver": "^5.4.1",
+						"sumchecker": "^2.0.2"
 					}
 				},
 				"fs-extra": {
@@ -838,9 +818,9 @@
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"jsonfile": {
@@ -849,7 +829,7 @@
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"minimist": {
@@ -870,7 +850,7 @@
 					"integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9"
+						"debug": "^2.2.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -887,36 +867,36 @@
 			}
 		},
 		"electron-builder-lib": {
-			"version": "19.55.2",
-			"resolved": "https://registry.npmjs.org/electron-builder-lib/-/electron-builder-lib-19.55.2.tgz",
-			"integrity": "sha512-XpwXqc7SlFU5hoggfVpgOJMoluu4Qb9hmV3oeermcmqGywe/bg2PGBNCF2b91ALkJRaQR2Bp1brr0RPu15KVGg==",
+			"version": "19.56.2",
+			"resolved": "https://registry.npmjs.org/electron-builder-lib/-/electron-builder-lib-19.56.2.tgz",
+			"integrity": "sha512-yZ1WtRqjbnT/ENVIAxqg4yJMQ/7PnokRdcym139ZvLAxv32Lt43HDVyCRvYOZPFeWKlD69aVfQLF4prXfEyROA==",
 			"dev": true,
 			"requires": {
-				"7zip-bin": "2.4.1",
+				"7zip-bin": "~3.0.0",
 				"asar-integrity": "0.2.4",
-				"async-exit-hook": "2.0.1",
-				"bluebird-lst": "1.0.5",
-				"builder-util": "4.2.1",
-				"builder-util-runtime": "4.0.3",
-				"chromium-pickle-js": "0.2.0",
-				"debug": "3.1.0",
-				"dmg-builder": "3.1.3",
-				"ejs": "2.5.7",
+				"async-exit-hook": "^2.0.1",
+				"bluebird-lst": "^1.0.5",
+				"builder-util": "4.2.4",
+				"builder-util-runtime": "4.0.4",
+				"chromium-pickle-js": "^0.2.0",
+				"debug": "^3.1.0",
+				"dmg-builder": "3.1.4",
+				"ejs": "^2.5.7",
 				"electron-osx-sign": "0.4.8",
-				"electron-publish": "19.55.2",
-				"fs-extra-p": "4.5.0",
-				"hosted-git-info": "2.5.0",
-				"is-ci": "1.1.0",
-				"isbinaryfile": "3.0.2",
-				"js-yaml": "3.10.0",
-				"lazy-val": "1.0.3",
-				"minimatch": "3.0.4",
-				"normalize-package-data": "2.4.0",
-				"plist": "2.1.0",
+				"electron-publish": "19.56.0",
+				"fs-extra-p": "^4.5.0",
+				"hosted-git-info": "^2.5.0",
+				"is-ci": "^1.1.0",
+				"isbinaryfile": "^3.0.2",
+				"js-yaml": "^3.10.0",
+				"lazy-val": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"normalize-package-data": "^2.4.0",
+				"plist": "^2.1.0",
 				"read-config-file": "2.1.1",
-				"sanitize-filename": "1.6.1",
-				"semver": "5.5.0",
-				"temp-file": "3.1.1"
+				"sanitize-filename": "^1.6.1",
+				"semver": "^5.5.0",
+				"temp-file": "^3.1.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -936,15 +916,15 @@
 			"integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"fs-extra": "0.30.0",
-				"home-path": "1.0.5",
-				"minimist": "1.2.0",
-				"nugget": "2.0.1",
-				"path-exists": "2.1.0",
-				"rc": "1.2.4",
-				"semver": "5.5.0",
-				"sumchecker": "1.3.1"
+				"debug": "^2.2.0",
+				"fs-extra": "^0.30.0",
+				"home-path": "^1.0.1",
+				"minimist": "^1.2.0",
+				"nugget": "^2.0.0",
+				"path-exists": "^2.1.0",
+				"rc": "^1.1.2",
+				"semver": "^5.3.0",
+				"sumchecker": "^1.2.0"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -953,11 +933,11 @@
 					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0",
-						"klaw": "1.3.1",
-						"path-is-absolute": "1.0.1",
-						"rimraf": "2.6.2"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
 				"minimist": {
@@ -974,12 +954,12 @@
 			"integrity": "sha1-8Ln63e2eHlTsNfqJh3tcbDTHvEA=",
 			"dev": true,
 			"requires": {
-				"bluebird": "3.5.1",
-				"compare-version": "0.1.2",
-				"debug": "2.6.9",
-				"isbinaryfile": "3.0.2",
-				"minimist": "1.2.0",
-				"plist": "2.1.0"
+				"bluebird": "^3.5.0",
+				"compare-version": "^0.1.2",
+				"debug": "^2.6.8",
+				"isbinaryfile": "^3.0.2",
+				"minimist": "^1.2.0",
+				"plist": "^2.1.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -991,17 +971,17 @@
 			}
 		},
 		"electron-publish": {
-			"version": "19.55.2",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.55.2.tgz",
-			"integrity": "sha512-SVfyAxUiOTAt2XtR508Ud27N9xJ63os3AGUj7Cchk0tBTME2HlbPgal4e5UJuw15N8jPCAsttu96AaRhFbGq5Q==",
+			"version": "19.56.0",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.56.0.tgz",
+			"integrity": "sha512-mJYJLaDKdxq/F1VAZwqany4LuWt9fEm2FMsKVCXdzYp1WAXhK5+J5Ng6rxc8n1BUWqYbs99tkRWp+5iyxiGcfA==",
 			"dev": true,
 			"requires": {
-				"bluebird-lst": "1.0.5",
-				"builder-util": "4.2.1",
-				"builder-util-runtime": "4.0.3",
-				"chalk": "2.3.0",
-				"fs-extra-p": "4.5.0",
-				"mime": "2.2.0"
+				"bluebird-lst": "^1.0.5",
+				"builder-util": "^4.2.2",
+				"builder-util-runtime": "^4.0.4",
+				"chalk": "^2.3.0",
+				"fs-extra-p": "^4.5.0",
+				"mime": "^2.2.0"
 			}
 		},
 		"env-paths": {
@@ -1015,13 +995,13 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es6-promise": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-			"integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+			"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -1042,13 +1022,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"extend": {
@@ -1085,9 +1065,9 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -1100,7 +1080,7 @@
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"dev": true,
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"find-up": {
@@ -1108,8 +1088,8 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"first-run": {
@@ -1117,8 +1097,8 @@
 			"resolved": "https://registry.npmjs.org/first-run/-/first-run-1.2.0.tgz",
 			"integrity": "sha1-zHrQLqhf+UbMKpyWxAL57E+XMSA=",
 			"requires": {
-				"configstore": "2.1.0",
-				"read-pkg-up": "1.0.1"
+				"configstore": "^2.0.0",
+				"read-pkg-up": "^1.0.1"
 			},
 			"dependencies": {
 				"configstore": {
@@ -1126,15 +1106,15 @@
 					"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
 					"integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
 					"requires": {
-						"dot-prop": "3.0.0",
-						"graceful-fs": "4.1.11",
-						"mkdirp": "0.5.1",
-						"object-assign": "4.1.1",
-						"os-tmpdir": "1.0.2",
-						"osenv": "0.1.4",
-						"uuid": "2.0.3",
-						"write-file-atomic": "1.3.4",
-						"xdg-basedir": "2.0.0"
+						"dot-prop": "^3.0.0",
+						"graceful-fs": "^4.1.2",
+						"mkdirp": "^0.5.0",
+						"object-assign": "^4.0.1",
+						"os-tmpdir": "^1.0.0",
+						"osenv": "^0.1.0",
+						"uuid": "^2.0.1",
+						"write-file-atomic": "^1.1.2",
+						"xdg-basedir": "^2.0.0"
 					}
 				},
 				"dot-prop": {
@@ -1142,7 +1122,7 @@
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 					"requires": {
-						"is-obj": "1.0.1"
+						"is-obj": "^1.0.0"
 					}
 				},
 				"uuid": {
@@ -1155,9 +1135,9 @@
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"xdg-basedir": {
@@ -1165,7 +1145,7 @@
 					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
 					"integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
 					"requires": {
-						"os-homedir": "1.0.2"
+						"os-homedir": "^1.0.0"
 					}
 				}
 			}
@@ -1176,13 +1156,13 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"asynckit": "^0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs-extra": {
@@ -1190,9 +1170,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 			"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.1"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			},
 			"dependencies": {
 				"jsonfile": {
@@ -1200,30 +1180,30 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				}
 			}
 		},
 		"fs-extra-p": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.5.0.tgz",
-			"integrity": "sha512-V/sdZmV+Yx3+nfXmjRTdBP4mVWCt7hZ0+ZOv+IZo+6fdkBxafaGsI7mYeNv/J3rWyz+mIToCFQORFSwt1bZw8Q==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.6.0.tgz",
+			"integrity": "sha512-nSVqB5UfWZQdU6pzBwcFh+7lJpBynnTsVtNJTBhAnAppUQRut0W7WeM271iS0TqQ9FoCqDXqyL0+h+h8DQUCpg==",
 			"dev": true,
 			"requires": {
-				"bluebird-lst": "1.0.5",
-				"fs-extra": "5.0.0"
+				"bluebird-lst": "^1.0.5",
+				"fs-extra": "^6.0.0"
 			},
 			"dependencies": {
 				"fs-extra": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+					"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"jsonfile": {
@@ -1232,7 +1212,7 @@
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				}
 			}
@@ -1265,7 +1245,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -1273,12 +1253,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"global-dirs": {
@@ -1287,7 +1267,7 @@
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.5"
+				"ini": "^1.3.4"
 			}
 		},
 		"got": {
@@ -1296,17 +1276,17 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"timed-out": "4.0.1",
-				"unzip-response": "2.0.1",
-				"url-parse-lax": "1.0.0"
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -1324,14 +1304,14 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
 		"hawk": {
@@ -1339,21 +1319,21 @@
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"home-path": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-			"integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
+			"integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
 			"dev": true
 		},
 		"hosted-git-info": {
@@ -1366,16 +1346,19 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"import-lazy": {
 			"version": "2.1.0",
@@ -1394,7 +1377,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"inflight": {
@@ -1402,8 +1385,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -1438,7 +1421,7 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-ci": {
@@ -1447,7 +1430,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.1.2"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-finite": {
@@ -1456,7 +1439,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -1465,7 +1448,7 @@
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-installed-globally": {
@@ -1474,8 +1457,8 @@
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 			"dev": true,
 			"requires": {
-				"global-dirs": "0.1.1",
-				"is-path-inside": "1.0.1"
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-npm": {
@@ -1495,7 +1478,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-redirect": {
@@ -1569,13 +1552,13 @@
 			"integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -1610,7 +1593,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsprim": {
@@ -1629,7 +1612,7 @@
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.9"
 			}
 		},
 		"latest-version": {
@@ -1638,7 +1621,7 @@
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 			"dev": true,
 			"requires": {
-				"package-json": "4.0.1"
+				"package-json": "^4.0.0"
 			}
 		},
 		"lazy-val": {
@@ -1653,7 +1636,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"load-json-file": {
@@ -1661,11 +1644,11 @@
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"locate-path": {
@@ -1674,8 +1657,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
@@ -1692,33 +1675,33 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 			"dev": true
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"make-dir": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -1741,7 +1724,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"meow": {
@@ -1750,16 +1733,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -1771,28 +1754,28 @@
 			}
 		},
 		"mime": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
-			"integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+			"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
 		"minimatch": {
@@ -1800,7 +1783,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -1828,7 +1811,7 @@
 			"requires": {
 				"decompress-zip": "0.3.0",
 				"fs-extra": "0.26.7",
-				"request": "2.83.0"
+				"request": "^2.79.0"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -1836,11 +1819,11 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
 					"integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0",
-						"klaw": "1.3.1",
-						"path-is-absolute": "1.0.1",
-						"rimraf": "2.6.2"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
 					}
 				}
 			}
@@ -1856,7 +1839,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1.1.1"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -1864,10 +1847,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -1876,7 +1859,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"nugget": {
@@ -1885,12 +1868,12 @@
 			"integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"minimist": "1.2.0",
-				"pretty-bytes": "1.0.4",
-				"progress-stream": "1.2.0",
-				"request": "2.83.0",
-				"single-line-log": "1.1.2",
+				"debug": "^2.1.3",
+				"minimist": "^1.1.0",
+				"pretty-bytes": "^1.0.2",
+				"progress-stream": "^1.1.0",
+				"request": "^2.45.0",
+				"single-line-log": "^1.1.2",
 				"throttleit": "0.0.2"
 			},
 			"dependencies": {
@@ -1929,7 +1912,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"os-homedir": {
@@ -1943,9 +1926,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -1958,8 +1941,8 @@
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
 			}
 		},
 		"p-finally": {
@@ -1974,7 +1957,7 @@
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -1983,7 +1966,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
@@ -1998,10 +1981,10 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "6.7.1",
-				"registry-auth-token": "3.3.1",
-				"registry-url": "3.1.0",
-				"semver": "5.5.0"
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
 			}
 		},
 		"parse-color": {
@@ -2010,7 +1993,7 @@
 			"integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
 			"dev": true,
 			"requires": {
-				"color-convert": "0.5.3"
+				"color-convert": "~0.5.0"
 			},
 			"dependencies": {
 				"color-convert": {
@@ -2026,7 +2009,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"path-exists": {
@@ -2034,7 +2017,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 			"requires": {
-				"pinkie-promise": "2.0.1"
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -2064,9 +2047,9 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pend": {
@@ -2095,7 +2078,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"plist": {
@@ -2106,7 +2089,7 @@
 			"requires": {
 				"base64-js": "1.2.0",
 				"xmlbuilder": "8.2.2",
-				"xmldom": "0.1.27"
+				"xmldom": "0.1.x"
 			}
 		},
 		"prepend-http": {
@@ -2121,14 +2104,14 @@
 			"integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "4.0.1",
-				"meow": "3.7.0"
+				"get-stdin": "^4.0.1",
+				"meow": "^3.1.0"
 			}
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true
 		},
 		"progress-stream": {
@@ -2137,8 +2120,8 @@
 			"integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
 			"dev": true,
 			"requires": {
-				"speedometer": "0.1.4",
-				"through2": "0.2.3"
+				"speedometer": "~0.1.2",
+				"through2": "~0.2.3"
 			}
 		},
 		"pseudomap": {
@@ -2158,20 +2141,20 @@
 			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"rc": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-			"integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+			"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 			"dev": true,
 			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
+				"deep-extend": "^0.5.1",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -2188,15 +2171,15 @@
 			"integrity": "sha512-tzV5MRYA1OIbjy0ZC3cKlQZMLyRYMJ7k37Inff0CH0fQGXFP9p0s0eJ3bQxnnvQDhPSspnW9fw9v2K0b+6TODg==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"bluebird-lst": "1.0.5",
-				"dotenv": "4.0.0",
-				"dotenv-expand": "4.0.1",
-				"fs-extra-p": "4.5.0",
-				"js-yaml": "3.10.0",
-				"json5": "0.5.1",
-				"lazy-val": "1.0.3"
+				"ajv": "^5.5.0",
+				"ajv-keywords": "^2.1.0",
+				"bluebird-lst": "^1.0.5",
+				"dotenv": "^4.0.0",
+				"dotenv-expand": "^4.0.1",
+				"fs-extra-p": "^4.5.0",
+				"js-yaml": "^3.10.0",
+				"json5": "^0.5.1",
+				"lazy-val": "^1.0.3"
 			}
 		},
 		"read-pkg": {
@@ -2204,9 +2187,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -2214,8 +2197,8 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			}
 		},
 		"readable-stream": {
@@ -2223,10 +2206,10 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
 				"isarray": "0.0.1",
-				"string_decoder": "0.10.31"
+				"string_decoder": "~0.10.x"
 			}
 		},
 		"rechoir": {
@@ -2234,7 +2217,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.5.0"
+				"resolve": "^1.1.6"
 			}
 		},
 		"redent": {
@@ -2243,18 +2226,18 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
 			}
 		},
 		"registry-auth-token": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-			"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.4",
-				"safe-buffer": "5.1.1"
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"registry-url": {
@@ -2263,7 +2246,7 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.4"
+				"rc": "^1.0.1"
 			}
 		},
 		"repeating": {
@@ -2272,36 +2255,35 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.86.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+			"integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			}
 		},
 		"require-directory": {
@@ -2321,7 +2303,7 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"rimraf": {
@@ -2329,13 +2311,19 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sanitize-filename": {
 			"version": "1.6.1",
@@ -2343,7 +2331,7 @@
 			"integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
 			"dev": true,
 			"requires": {
-				"truncate-utf8-bytes": "1.0.2"
+				"truncate-utf8-bytes": "^1.0.0"
 			}
 		},
 		"sax": {
@@ -2363,7 +2351,7 @@
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 			"dev": true,
 			"requires": {
-				"semver": "5.5.0"
+				"semver": "^5.0.3"
 			}
 		},
 		"set-blocking": {
@@ -2378,7 +2366,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -2392,9 +2380,9 @@
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.1.0",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
 		},
 		"signal-exit": {
@@ -2409,7 +2397,7 @@
 			"integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2"
+				"string-width": "^1.0.1"
 			}
 		},
 		"slide": {
@@ -2422,7 +2410,7 @@
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"source-map": {
@@ -2432,12 +2420,13 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.2.tgz",
-			"integrity": "sha512-9zHceZbQwERaMK1MiFguvx1dL9GQPLXInr2D/wUxAsuV6ZKc9F0DHYWeloMcalkYRbtanwqUakoDjvj55cL/4A==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"spdx-correct": {
@@ -2445,7 +2434,7 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -2471,18 +2460,18 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stat-mode": {
@@ -2497,9 +2486,9 @@
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string_decoder": {
@@ -2507,18 +2496,13 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -2526,7 +2510,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-eof": {
@@ -2541,7 +2525,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "4.0.1"
+				"get-stdin": "^4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -2556,29 +2540,29 @@
 			"integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"es6-promise": "4.2.2"
+				"debug": "^2.2.0",
+				"es6-promise": "^4.0.5"
 			}
 		},
 		"supports-color": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"dev": true,
 			"requires": {
-				"has-flag": "2.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"temp-file": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.1.1.tgz",
-			"integrity": "sha512-W/6SJgtg2SE/5rxgwUwoDhdSXrvUWQBpgKJglaAe6S7mk1kLkI+LUbY/jPZBu3UhydDJZstNNd7AJhnZ0UZHtw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.1.2.tgz",
+			"integrity": "sha512-s5JJnUbvV6QaKBxBJm6wDpKIVVvr/ssrb8Cdaz2iaXcjFMtWX+OGBwY+UTvARoWYI5HlKaoD7xFJSpo0jJUlbA==",
 			"dev": true,
 			"requires": {
-				"async-exit-hook": "2.0.1",
-				"bluebird-lst": "1.0.5",
-				"fs-extra-p": "4.5.0",
-				"lazy-val": "1.0.3"
+				"async-exit-hook": "^2.0.1",
+				"bluebird-lst": "^1.0.5",
+				"fs-extra-p": "^4.6.0",
+				"lazy-val": "^1.0.3"
 			}
 		},
 		"term-size": {
@@ -2587,7 +2571,7 @@
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0"
+				"execa": "^0.7.0"
 			}
 		},
 		"throttleit": {
@@ -2602,8 +2586,8 @@
 			"integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "1.1.14",
-				"xtend": "2.1.2"
+				"readable-stream": "~1.1.9",
+				"xtend": "~2.1.1"
 			}
 		},
 		"timed-out": {
@@ -2617,7 +2601,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
 			"integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.1"
 			}
 		},
 		"touch": {
@@ -2625,7 +2609,7 @@
 			"resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
 			"integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
 			"requires": {
-				"nopt": "1.0.10"
+				"nopt": "~1.0.10"
 			},
 			"dependencies": {
 				"nopt": {
@@ -2633,17 +2617,17 @@
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
 					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
 					"requires": {
-						"abbrev": "1.1.1"
+						"abbrev": "1"
 					}
 				}
 			}
 		},
 		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"traverse": {
@@ -2663,7 +2647,7 @@
 			"integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
 			"dev": true,
 			"requires": {
-				"utf8-byte-length": "1.0.4"
+				"utf8-byte-length": "^1.0.1"
 			}
 		},
 		"tunnel-agent": {
@@ -2671,7 +2655,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -2692,7 +2676,7 @@
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 			"dev": true,
 			"requires": {
-				"crypto-random-string": "1.0.0"
+				"crypto-random-string": "^1.0.0"
 			}
 		},
 		"universalify": {
@@ -2707,20 +2691,21 @@
 			"dev": true
 		},
 		"update-notifier": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-			"integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 			"dev": true,
 			"requires": {
-				"boxen": "1.3.0",
-				"chalk": "2.3.0",
-				"configstore": "3.1.1",
-				"import-lazy": "2.1.0",
-				"is-installed-globally": "0.1.0",
-				"is-npm": "1.0.0",
-				"latest-version": "3.1.0",
-				"semver-diff": "2.1.0",
-				"xdg-basedir": "3.0.0"
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			}
 		},
 		"url-parse-lax": {
@@ -2729,7 +2714,7 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"utf8-byte-length": {
@@ -2754,8 +2739,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"verror": {
@@ -2763,9 +2748,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"which": {
@@ -2774,7 +2759,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -2789,7 +2774,7 @@
 			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2810,8 +2795,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -2820,7 +2805,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -2831,8 +2816,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"wrappy": {
@@ -2846,9 +2831,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"xdg-basedir": {
@@ -2875,7 +2860,7 @@
 			"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
 			"dev": true,
 			"requires": {
-				"object-keys": "0.4.0"
+				"object-keys": "~0.4.0"
 			}
 		},
 		"y18n": {
@@ -2891,23 +2876,23 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.1.tgz",
-			"integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+			"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 			"dev": true,
 			"requires": {
-				"cliui": "4.0.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "8.1.0"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2922,7 +2907,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -2937,8 +2922,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -2947,18 +2932,18 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2975,7 +2960,7 @@
 			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
 			"dev": true,
 			"requires": {
-				"fd-slicer": "1.0.1"
+				"fd-slicer": "~1.0.1"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
 	},
 	"license": "MIT",
 	"devDependencies": {
-		"electron": "^1.6.16",
-		"electron-builder": "^19.55.2"
+		"electron": "^1.8.7",
+		"electron-builder": "^19.56.2"
 	},
 	"dependencies": {
-		"asar": "^0.14.0",
+		"asar": "^0.14.3",
 		"bootstrap": "^3.3.7",
 		"first-run": "^1.2.0",
 		"fs-extra": "^5.0.0",


### PR DESCRIPTION
Fundementally changes made to the way template save files work. Previously you would have to keep track of the template saves yourself, and it required lots of work and renaming files. Now the template saves are saved directly into the .otts file. Interface has also been changed to facilitate this. This makes it easier to add, update or remove template save files. It also means the tas savefile is completely portable.

Also updated some npm packages.